### PR TITLE
refactor: 헥사고날 아키텍처 개선 및 코드 품질 향상

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -38,3 +38,6 @@ out/
 
 ### Kotlin ###
 .kotlin
+
+### Claude Code ###
+.omc/

--- a/README.md
+++ b/README.md
@@ -1,8 +1,251 @@
-## Meet Football
-- 해외축구 정보를 모아볼 수 있는 프로젝트입니다.
+# Meet Football
 
-- 사용 기술
-  - 프레임워크: Spring Boot (3.3.0) 
-  - 빌드: Gradle (8.8)
-  - Language: Kotlin (1.9.24)
-  - Database: MySQL
+해외 축구 정보를 수집·제공하는 REST API 서버입니다.
+외부 Football API에서 팀·선수 데이터를 마이그레이션하여 자체 DB에 저장하고, 클라이언트에 일관된 인터페이스로 제공합니다.
+
+---
+
+## 목차
+
+- [프로젝트 목적](#프로젝트-목적)
+- [사용 기술](#사용-기술)
+- [프로젝트 아키텍처](#프로젝트-아키텍처)
+- [패키지 구조](#패키지-구조)
+- [주요 설계 결정](#주요-설계-결정)
+- [API 명세](#api-명세)
+- [로컬 실행](#로컬-실행)
+
+---
+
+## 프로젝트 목적
+
+| 항목 | 내용 |
+|---|---|
+| 핵심 기능 | 외부 Football Data API(football-data.org)로부터 팀 데이터를 수집하고 자체 DB에 저장 |
+| 제공 기능 | 팀, 유저 정보 조회 REST API |
+| 기술 목표 | 헥사고날 아키텍처 기반 클린 코드, 도메인과 인프라 관심사 분리 |
+
+---
+
+## 사용 기술
+
+| 분류 | 기술 | 버전 |
+|---|---|---|
+| Language | Kotlin | 1.9.24 |
+| Framework | Spring Boot | 3.3.0 |
+| Build | Gradle | 8.8 |
+| ORM | Spring Data JPA / Hibernate | 3.3.0 |
+| DB | MySQL | 8.x |
+| Security | Spring Security | 3.3.0 |
+| API Docs | SpringDoc OpenAPI (Swagger UI) | 2.5.0 |
+| HTTP Client | Spring RestClient | (Spring Boot 내장) |
+| Test | JUnit5, Spring Boot Test | 3.3.0 |
+| JVM | Java | 17 |
+
+---
+
+## 프로젝트 아키텍처
+
+### 헥사고날 아키텍처 (Ports & Adapters)
+
+외부 시스템(Web, DB, 외부 API)과 비즈니스 로직을 명확하게 분리합니다.
+의존성 방향은 항상 **외부 → 내부(도메인)** 단방향을 유지합니다.
+
+```
+┌─────────────────────────────────────────────────────────┐
+│                   Inbound Adapters                      │
+│         (REST Controller / @Web)                        │
+└────────────────────────┬────────────────────────────────┘
+                         │  Input Port (UseCase Interface)
+                         ▼
+┌─────────────────────────────────────────────────────────┐
+│                  Application Core                       │
+│                                                         │
+│   ┌─────────────────────────────────────────────────┐   │
+│   │              Domain Service (@UseCase)          │   │
+│   │   - 비즈니스 규칙 구현                           │   │
+│   │   - 외부 의존성 없음                             │   │
+│   └─────────────────────────────────────────────────┘   │
+│                                                         │
+│   ┌──────────────┐        ┌────────────────────────┐    │
+│   │ Domain Entity│        │   Output Port          │    │
+│   │ (순수 Kotlin) │        │   (DB / HTTP Interface)│    │
+│   └──────────────┘        └────────────────────────┘    │
+└─────────────────────────────────────────────────────────┘
+                         │  Output Port 구현체
+                         ▼
+┌─────────────────────────────────────────────────────────┐
+│                  Outbound Adapters                      │
+│     JPA Persistence (@Persistence) / HTTP Client       │
+└─────────────────────────────────────────────────────────┘
+```
+
+### 레이어별 역할
+
+| 레이어 | 패키지 | 어노테이션 | 역할 |
+|---|---|---|---|
+| Inbound Adapter | `adapter.{domain}.in.web` | `@Web` | HTTP 요청 수신, DTO 변환 |
+| Input Port | `application.{domain}.port.in` | (interface) | UseCase 계약 정의 |
+| Domain Service | `application.{domain}.domain.service` | `@UseCase` | 비즈니스 로직 |
+| Domain Entity | `application.{domain}.domain.entity` | - | 순수 도메인 객체 |
+| Output Port | `application.{domain}.port.out` | (interface) | DB/외부 API 계약 정의 |
+| Outbound Adapter | `adapter.{domain}.out.persistence` | `@Persistence` | JPA 엔티티, Repository |
+| HTTP Adapter | `adapter.base.out.httpclient` | `@HttpClient` | 외부 API 호출 |
+
+### 도메인 흐름 예시 — 팀 마이그레이션
+
+```
+POST /api/teams/migration
+        │
+        ▼
+MigrateTeamController   (@Web)
+        │  MigrateTeamUseCase.migrate()
+        ▼
+MigrateTeamService      (@UseCase)
+        │  HttpClientPort.get()          → football-data.org API 호출
+        │  FindTeamByApiIdPort.find()    → 기존 팀 존재 여부 확인
+        │  SaveTeamPort.save()           → 신규 저장
+        │  UpdateTeamPort.update()       → 기존 데이터 갱신
+        ▼
+  JPA Adapters          (@Persistence)
+        │
+        ▼
+     MySQL DB
+```
+
+### 에러 처리 — Result 타입
+
+예외를 던지는 대신 `Result<T>` sealed class로 성공/실패를 명시적으로 표현합니다.
+
+```kotlin
+sealed class Result<T> {
+    data class Success<T>(val data: T) : Result<T>()
+    data class Fail<T>(val error: Error) : Result<T>()
+}
+```
+
+컨트롤러 레이어의 `CustomResponseEntity`가 `Result`를 HTTP 응답으로 자동 변환합니다.
+
+---
+
+## 패키지 구조
+
+```
+src/main/kotlin/com/meetfootball/
+│
+├── MeetfootballApplication.kt
+│
+├── adapter/
+│   ├── base/                              # 공통 어노테이션 & 응답 처리
+│   │   ├── Web.kt                         # @RestController + @RequestMapping 합성
+│   │   ├── UseCase.kt                     # @Component 합성 (도메인 서비스용)
+│   │   ├── Persistence.kt                 # @Component 합성 (JPA 어댑터용)
+│   │   ├── HttpClient.kt                  # @Component 합성 (HTTP 어댑터용)
+│   │   └── in/web/response/
+│   │       ├── ApiResponse.kt             # 응답 추상 기반 클래스
+│   │       ├── CustomResponseEntity.kt    # Result<T> → ResponseEntity 변환
+│   │       └── ExceptionResponse.kt      # 에러 응답 DTO
+│   │
+│   ├── team/
+│   │   ├── in/web/
+│   │   │   └── MigrateTeamController.kt  # POST /api/teams/migration
+│   │   └── out/persistence/jpa/
+│   │       ├── Team.kt                    # JPA 엔티티
+│   │       ├── TeamRepository.kt          # Spring Data JPA
+│   │       ├── TeamMapper.kt              # JPA ↔ Domain Entity 변환
+│   │       ├── SaveTeamAdapter.kt
+│   │       ├── UpdateTeamAdapter.kt
+│   │       └── FindTeamByApiIdAdapter.kt
+│   │
+│   ├── user/
+│   │   ├── in/web/
+│   │   │   ├── FindUserByIdController.kt  # GET /api/users/by-id/{id}
+│   │   │   └── response/
+│   │   │       └── FindUserByIdResponse.kt
+│   │   └── out/persistence/jpa/
+│   │       ├── User.kt
+│   │       ├── UserRepository.kt
+│   │       ├── UserMapper.kt
+│   │       └── FindUserByIdAdapter.kt
+│   │
+│   └── base/out/httpclient/restclient/
+│       └── HttpClientAdapter.kt           # Spring RestClient 기반 외부 API 호출
+│
+├── application/
+│   ├── base/
+│   │   ├── Result.kt                      # 함수형 에러 핸들링
+│   │   └── Error.kt                       # 도메인 에러 sealed class
+│   │
+│   ├── team/
+│   │   ├── domain/
+│   │   │   ├── entity/TeamEntity.kt
+│   │   │   └── service/MigrateTeamService.kt
+│   │   └── port/
+│   │       ├── in/MigrateTeamUseCase.kt
+│   │       └── out/                        # SaveTeamPort, UpdateTeamPort 등
+│   │
+│   └── user/
+│       ├── domain/
+│       │   ├── entity/UserEntity.kt
+│       │   └── service/FindUserByIdService.kt
+│       └── port/
+│           ├── in/FindUserByIdUseCase.kt
+│           └── out/FindUserByIdDbPort.kt
+│
+├── config/
+│   ├── JpaConfig.kt                       # @EnableJpaAuditing
+│   ├── SecurityConfig.kt                  # Spring Security 설정
+│   └── SwaggerConfig.kt                   # OpenAPI 3.0 설정
+│
+├── enum/
+│   └── ErrorCode.kt
+│
+└── sql/
+    └── create-team.sql                    # 팀 테이블 DDL
+```
+
+---
+
+## 주요 설계 결정
+
+### 합성 어노테이션 (Meta-Annotation)
+
+`@Web`, `@UseCase`, `@Persistence`, `@HttpClient`는 Spring 어노테이션을 합성한 커스텀 어노테이션입니다.
+레이어 역할을 코드에서 명시적으로 표현하고, 전체 검색/필터링이 용이합니다.
+
+### ddl-auto: validate
+
+스키마 변경은 `sql/` 하위 DDL 파일로 직접 관리합니다.
+Hibernate가 자동으로 스키마를 수정하지 않아 운영 환경 안전성을 확보합니다.
+
+### Swagger UI
+
+`/v1/api-docs/swagger` 경로에서 API 명세를 확인할 수 있습니다.
+
+---
+
+## API 명세
+
+| Method | URL | 설명 |
+|---|---|---|
+| `GET` | `/api/users/by-id/{id}` | ID로 유저 조회 |
+| `POST` | `/api/teams/migration` | 외부 API에서 팀 데이터 마이그레이션 |
+
+전체 API 명세는 Swagger UI에서 확인하세요: `http://localhost:8080/v1/api-docs/swagger`
+
+---
+
+## 로컬 실행
+
+**사전 요구사항:** Java 17, MySQL 8.x
+
+```bash
+# 1. DB 생성
+mysql -u root -p -e "CREATE DATABASE meetfootball CHARACTER SET utf8mb4;"
+
+# 2. 팀 테이블 생성
+mysql -u root -p meetfootball < src/main/kotlin/com/meetfootball/sql/create-team.sql
+
+# 3. 환경변수 설정 후 실행
+DB_USERNAME=your_user DB_PASSWORD=your_password ./gradlew bootRun
+```

--- a/src/main/kotlin/com/meetfootball/adapter/base/in/web/response/CustomResponseEntity.kt
+++ b/src/main/kotlin/com/meetfootball/adapter/base/in/web/response/CustomResponseEntity.kt
@@ -6,12 +6,13 @@ import org.springframework.http.ResponseEntity
 
 class CustomResponseEntity {
     companion object {
-        inline fun <reified T, reified U: ApiResponse> toResponse(
-            result: Result<T>
+        fun <T> toResponse(
+            result: Result<T>,
+            successMapper: (T) -> ApiResponse,
         ): ResponseEntity<ApiResponse> {
             return when (result) {
-                is Result.Success<T> -> ResponseEntity(U::class.constructors.first().call(result), HttpStatus.OK)
-                is Result.Fail<T> -> ResponseEntity(ExceptionResponse(result), HttpStatus.valueOf(result.error.statusCode))
+                is Result.Success -> ResponseEntity(successMapper(result.data), HttpStatus.OK)
+                is Result.Fail -> ResponseEntity(ExceptionResponse(result), HttpStatus.valueOf(result.error.statusCode))
             }
         }
     }

--- a/src/main/kotlin/com/meetfootball/adapter/user/in/web/FindUserByIdController.kt
+++ b/src/main/kotlin/com/meetfootball/adapter/user/in/web/FindUserByIdController.kt
@@ -4,7 +4,6 @@ import com.meetfootball.adapter.base.Web
 import com.meetfootball.adapter.base.`in`.web.response.ApiResponse
 import com.meetfootball.adapter.base.`in`.web.response.CustomResponseEntity
 import com.meetfootball.adapter.user.`in`.web.response.FindUserByIdResponse
-import com.meetfootball.application.user.domain.entity.UserEntity
 import com.meetfootball.application.user.port.`in`.FindUserByIdUseCase
 import org.springframework.http.ResponseEntity
 import org.springframework.web.bind.annotation.GetMapping
@@ -12,11 +11,11 @@ import org.springframework.web.bind.annotation.PathVariable
 
 @Web(path = "/api/users")
 class FindUserByIdController(
-    private val findUserByIdUseCase: FindUserByIdUseCase
+    private val findUserByIdUseCase: FindUserByIdUseCase,
 ) {
     @GetMapping("/by-id/{id}")
     fun findUserById(@PathVariable id: Long): ResponseEntity<ApiResponse> {
-        val result = this.findUserByIdUseCase.findUserById(id)
-        return CustomResponseEntity.toResponse<UserEntity, FindUserByIdResponse>(result)
+        val result = findUserByIdUseCase.findUserById(id)
+        return CustomResponseEntity.toResponse(result) { FindUserByIdResponse(it) }
     }
 }

--- a/src/main/kotlin/com/meetfootball/adapter/user/in/web/response/FindUserByIdResponse.kt
+++ b/src/main/kotlin/com/meetfootball/adapter/user/in/web/response/FindUserByIdResponse.kt
@@ -1,13 +1,14 @@
 package com.meetfootball.adapter.user.`in`.web.response
 
 import com.meetfootball.adapter.base.`in`.web.response.ApiResponse
-import com.meetfootball.application.base.Result
 import com.meetfootball.application.user.domain.entity.UserEntity
 
 data class FindUserByIdResponse(
-    private val result: Result.Success<UserEntity>
-): ApiResponse() {
-    val name: String = result.data.name
-
-    val email: String = result.data.email
+    val name: String,
+    val email: String,
+) : ApiResponse() {
+    constructor(user: UserEntity) : this(
+        name = user.name,
+        email = user.email,
+    )
 }

--- a/src/main/kotlin/com/meetfootball/adapter/user/out/persistence/jpa/FindUserByIdAdapter.kt
+++ b/src/main/kotlin/com/meetfootball/adapter/user/out/persistence/jpa/FindUserByIdAdapter.kt
@@ -2,16 +2,14 @@ package com.meetfootball.adapter.user.out.persistence.jpa
 
 import com.meetfootball.adapter.base.Persistence
 import com.meetfootball.application.user.domain.entity.UserEntity
-import com.meetfootball.application.user.port.out.FindUserByIdDbPort
+import com.meetfootball.application.user.port.out.LoadUserPort
 import org.springframework.data.repository.findByIdOrNull
 
 @Persistence
 class FindUserByIdAdapter(
     private val jpaUserRepository: UserRepository
-): FindUserByIdDbPort {
-    override fun findUserById(id: Long): UserEntity? {
-        val jpaUser = this.jpaUserRepository.findByIdOrNull(id)
-
-        return jpaUser?.let { UserMapper.toDomainEntity(it) }
+) : LoadUserPort {
+    override fun findById(id: Long): UserEntity? {
+        return jpaUserRepository.findByIdOrNull(id)?.let { UserMapper.toDomainEntity(it) }
     }
 }

--- a/src/main/kotlin/com/meetfootball/adapter/user/out/persistence/jpa/User.kt
+++ b/src/main/kotlin/com/meetfootball/adapter/user/out/persistence/jpa/User.kt
@@ -3,10 +3,12 @@ package com.meetfootball.adapter.user.out.persistence.jpa
 import jakarta.persistence.*
 import org.springframework.data.annotation.CreatedDate
 import org.springframework.data.annotation.LastModifiedDate
+import org.springframework.data.jpa.domain.support.AuditingEntityListener
 import java.time.LocalDateTime
 
 @Entity
 @Table(name = "users")
+@EntityListeners(AuditingEntityListener::class)
 class User(
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)

--- a/src/main/kotlin/com/meetfootball/application/base/UseCase.kt
+++ b/src/main/kotlin/com/meetfootball/application/base/UseCase.kt
@@ -1,4 +1,4 @@
-package com.meetfootball.adapter.base
+package com.meetfootball.application.base
 
 import org.springframework.core.annotation.AliasFor
 import org.springframework.stereotype.Component

--- a/src/main/kotlin/com/meetfootball/application/user/domain/service/FindUserByIdService.kt
+++ b/src/main/kotlin/com/meetfootball/application/user/domain/service/FindUserByIdService.kt
@@ -1,19 +1,18 @@
 package com.meetfootball.application.user.domain.service
 
-import com.meetfootball.adapter.base.UseCase
 import com.meetfootball.application.base.Error
 import com.meetfootball.application.base.Result
+import com.meetfootball.application.base.UseCase
 import com.meetfootball.application.user.domain.entity.UserEntity
 import com.meetfootball.application.user.port.`in`.FindUserByIdUseCase
-import com.meetfootball.application.user.port.out.FindUserByIdDbPort
+import com.meetfootball.application.user.port.out.LoadUserPort
 
 @UseCase
 class FindUserByIdService(
-    private val findUserByIdDbPort: FindUserByIdDbPort
+    private val loadUserPort: LoadUserPort
 ): FindUserByIdUseCase {
     override fun findUserById(id: Long): Result<UserEntity> {
-        val user = this.findUserByIdDbPort.findUserById(id)
-
+        val user = loadUserPort.findById(id)
         return if (user != null) Result.Success(user) else Result.Fail(Error.NotFound)
     }
 }

--- a/src/main/kotlin/com/meetfootball/application/user/port/out/LoadUserPort.kt
+++ b/src/main/kotlin/com/meetfootball/application/user/port/out/LoadUserPort.kt
@@ -2,6 +2,6 @@ package com.meetfootball.application.user.port.out
 
 import com.meetfootball.application.user.domain.entity.UserEntity
 
-interface FindUserByIdDbPort {
-    fun findUserById(id: Long): UserEntity?
+interface LoadUserPort {
+    fun findById(id: Long): UserEntity?
 }

--- a/src/test/kotlin/com/meetfootball/adapter/user/in/web/FindUserByIdControllerTest.kt
+++ b/src/test/kotlin/com/meetfootball/adapter/user/in/web/FindUserByIdControllerTest.kt
@@ -1,0 +1,46 @@
+package com.meetfootball.adapter.user.`in`.web
+
+import com.meetfootball.application.base.Error
+import com.meetfootball.application.base.Result
+import com.meetfootball.application.user.domain.entity.UserEntity
+import com.meetfootball.application.user.port.`in`.FindUserByIdUseCase
+import org.junit.jupiter.api.Test
+import org.mockito.BDDMockito.given
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest
+import org.springframework.boot.test.mock.mockito.MockBean
+import org.springframework.test.web.servlet.MockMvc
+import org.springframework.test.web.servlet.get
+
+@WebMvcTest(FindUserByIdController::class)
+class FindUserByIdControllerTest {
+
+    @Autowired
+    private lateinit var mockMvc: MockMvc
+
+    @MockBean
+    private lateinit var findUserByIdUseCase: FindUserByIdUseCase
+
+    @Test
+    fun `유저 조회 성공 시 200과 유저 정보를 반환한다`() {
+        val user = UserEntity(name = "홍길동", email = "hong@test.com", password = "password")
+        given(findUserByIdUseCase.findUserById(1L)).willReturn(Result.Success(user))
+
+        mockMvc.get("/api/users/by-id/1")
+            .andExpect {
+                status { isOk() }
+                jsonPath("$.name") { value("홍길동") }
+                jsonPath("$.email") { value("hong@test.com") }
+            }
+    }
+
+    @Test
+    fun `존재하지 않는 유저 조회 시 404를 반환한다`() {
+        given(findUserByIdUseCase.findUserById(99L)).willReturn(Result.Fail(Error.NotFound))
+
+        mockMvc.get("/api/users/by-id/99")
+            .andExpect {
+                status { isNotFound() }
+            }
+    }
+}

--- a/src/test/kotlin/com/meetfootball/application/user/domain/service/FindUserByIdServiceTest.kt
+++ b/src/test/kotlin/com/meetfootball/application/user/domain/service/FindUserByIdServiceTest.kt
@@ -1,0 +1,38 @@
+package com.meetfootball.application.user.domain.service
+
+import com.meetfootball.application.base.Result
+import com.meetfootball.application.user.domain.entity.UserEntity
+import com.meetfootball.application.user.port.out.LoadUserPort
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Test
+import org.mockito.Mockito.mock
+import org.mockito.Mockito.`when`
+
+class FindUserByIdServiceTest {
+
+    private val loadUserPort: LoadUserPort = mock(LoadUserPort::class.java)
+    private val service = FindUserByIdService(loadUserPort)
+
+    @Test
+    fun `유저가 존재하면 Success를 반환한다`() {
+        val user = UserEntity(name = "홍길동", email = "hong@test.com", password = "password")
+        `when`(loadUserPort.findById(1L)).thenReturn(user)
+
+        val result = service.findUserById(1L)
+
+        assertTrue(result is Result.Success)
+        assertEquals("홍길동", (result as Result.Success).data.name)
+        assertEquals("hong@test.com", result.data.email)
+    }
+
+    @Test
+    fun `유저가 존재하지 않으면 Fail을 반환한다`() {
+        `when`(loadUserPort.findById(99L)).thenReturn(null)
+
+        val result = service.findUserById(99L)
+
+        assertTrue(result is Result.Fail)
+        assertEquals(404, (result as Result.Fail).error.statusCode)
+    }
+}


### PR DESCRIPTION
## 요약

15년차 시니어 백엔드 개발자 관점의 코드 리뷰를 반영한 개선사항입니다.
아키텍처 방향 위반, 불명확한 네이밍, 리플렉션 기반 취약 코드, JPA 감사 버그를 수정하고 테스트를 보충하였습니다.

## 작업 내용

**[아키텍처]**
- `UseCase` 어노테이션 이동: `adapter.base` → `application.base`
  - 도메인 서비스가 adapter 레이어에 의존하는 방향 위반 수정
- `FindUserByIdDbPort` → `LoadUserPort` 리네임
  - 포트 명칭에서 인프라 구현 세부사항(`Db`) 제거, 헥사고날 명명 규칙 준수

**[비즈니스 로직]**
- `CustomResponseEntity` 리플렉션(`constructors.first().call()`) 제거 → lambda mapper(`successMapper: (T) -> ApiResponse`)로 교체
  - 런타임 오류 위험 제거, 타입 안전성 확보
- `FindUserByIdResponse`가 `Result.Success<UserEntity>`를 직접 받던 구조 개선 → `UserEntity`만 받도록 분리
  - 응답 DTO와 Result 타입 간 결합도 제거
- `FindUserByIdService` 불필요한 `this.` 참조 제거

**[JPA]**
- `User` 엔티티에 `@EntityListeners(AuditingEntityListener::class)` 추가
  - 누락으로 인해 `@CreatedDate` / `@LastModifiedDate`가 동작하지 않던 버그 수정

**[테스트]**
- `FindUserByIdServiceTest` 추가 (단위 테스트, Mockito)
- `FindUserByIdControllerTest` 추가 (WebMvcTest 슬라이스 테스트)

## 참고 사항

- 기존 API 스펙(`GET /api/users/by-id/{id}`) 및 응답 형식 변경 없음
- `feature/team` 브랜치와 독립적인 변경사항

## 관련 이슈
- Close #4