### PR TITLE
ci: GitHub Actions CI 파이프라인 도입

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,4 +1,4 @@
-name: Kotlin Spring Boot CI (All Branches)
+name: CI
 
 on:
   push:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,46 @@
+name: Kotlin Spring Boot CI (All Branches)
+
+on:
+  push:
+    branches:
+      - '**'
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout Repository
+        uses: actions/checkout@v4
+
+      - name: Set up JDK 17
+        uses: actions/setup-java@v4
+        with:
+          java-version: '17'
+          distribution: 'temurin'
+          cache: gradle
+
+      - name: Grant execute permission for gradlew
+        run: chmod +x gradlew
+
+      - name: Run Unit Tests with Gradle
+        run: ./gradlew test
+
+      - name: Send Email on Failure
+        if: failure()
+        uses: dawidd6/action-send-mail@v3
+        with:
+          server_address: smtp.gmail.com
+          server_port: 465
+          username: ${{ secrets.MAIL_USERNAME }}
+          password: ${{ secrets.MAIL_PASSWORD }}
+          subject: "❌ [CI Failed] ${{ github.repository }} - ${{ github.ref_name }}"
+          to: ${{ github.event.pusher.email }}
+          from: GitHub Actions CI
+          body: |
+            테스트 실패 알림입니다.
+
+            - Repository: ${{ github.repository }}
+            - Branch: ${{ github.ref_name }}
+            - Committer: ${{ github.actor }}
+            - Commit Message: ${{ github.event.head_commit.message }}
+            - Log Link: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,23 +24,3 @@ jobs:
 
       - name: Run Unit Tests with Gradle
         run: ./gradlew test
-
-      - name: Send Email on Failure
-        if: failure()
-        uses: dawidd6/action-send-mail@v3
-        with:
-          server_address: smtp.gmail.com
-          server_port: 465
-          username: ${{ secrets.MAIL_USERNAME }}
-          password: ${{ secrets.MAIL_PASSWORD }}
-          subject: "❌ [CI Failed] ${{ github.repository }} - ${{ github.ref_name }}"
-          to: ${{ github.event.pusher.email }}
-          from: GitHub Actions CI
-          body: |
-            테스트 실패 알림입니다.
-
-            - Repository: ${{ github.repository }}
-            - Branch: ${{ github.ref_name }}
-            - Committer: ${{ github.actor }}
-            - Commit Message: ${{ github.event.head_commit.message }}
-            - Log Link: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -31,6 +31,7 @@ dependencies {
 	testImplementation("org.jetbrains.kotlin:kotlin-test-junit5")
 	testImplementation("org.springframework.security:spring-security-test")
 	testRuntimeOnly("org.junit.platform:junit-platform-launcher")
+	testRuntimeOnly("com.h2database:h2")
 }
 
 kotlin {

--- a/src/test/kotlin/com/meetfootball/adapter/user/in/web/FindUserByIdControllerTest.kt
+++ b/src/test/kotlin/com/meetfootball/adapter/user/in/web/FindUserByIdControllerTest.kt
@@ -4,15 +4,18 @@ import com.meetfootball.application.base.Error
 import com.meetfootball.application.base.Result
 import com.meetfootball.application.user.domain.entity.UserEntity
 import com.meetfootball.application.user.port.`in`.FindUserByIdUseCase
+import com.meetfootball.config.SecurityConfig
 import org.junit.jupiter.api.Test
 import org.mockito.BDDMockito.given
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest
 import org.springframework.boot.test.mock.mockito.MockBean
+import org.springframework.context.annotation.Import
 import org.springframework.test.web.servlet.MockMvc
 import org.springframework.test.web.servlet.get
 
 @WebMvcTest(FindUserByIdController::class)
+@Import(SecurityConfig::class)
 class FindUserByIdControllerTest {
 
     @Autowired

--- a/src/test/resources/application.yml
+++ b/src/test/resources/application.yml
@@ -1,0 +1,10 @@
+spring:
+  datasource:
+    url: jdbc:h2:mem:testdb;MODE=MySQL;DB_CLOSE_DELAY=-1
+    driver-class-name: org.h2.Driver
+    username: sa
+    password:
+  jpa:
+    hibernate:
+      ddl-auto: create-drop
+    show-sql: false


### PR DESCRIPTION
## 요약

모든 브랜치 push 시 Gradle 유닛 테스트를 자동 실행하는 GitHub Actions CI 파이프라인을 도입합니다.
알림은 GitHub Notification 설정을 통해 처리합니다.

## 작업 내용

- `.github/workflows/ci.yml` 추가
  - 트리거: 모든 브랜치(`**`) push
  - JDK 17 (temurin) 설치 + Gradle 캐시 적용으로 빌드 시간 단축
  - `./gradlew test` 자동 실행

## 참고 사항

- CI 실패 시 머지 차단은 GitHub 저장소 설정에서 별도 구성 필요
  - Settings → Branches → Branch protection rules → "Require status checks to pass before merging" 활성화

## 관련 이슈
- Close #5